### PR TITLE
Make qt6-base and libxml2 without ICU support

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -131,7 +131,7 @@ jobs:
           chmod +x ./*.sh
           sh ${{ matrix.script }}.sh
           mkdir ./dist
-          mv ./llvm-libs-*.pkg.tar.* ./dist
+          mv ./*.pkg.tar.* ./dist
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -36,6 +36,22 @@ jobs:
             platform: linux/arm64
             runs-on: ubuntu-24.04-arm
             script: llvm-nano
+          - arch: x86_64
+            platform: linux/amd64
+            runs-on: ubuntu-24.04
+            script: iculess-libxml2
+          - arch: aarch64
+            platform: linux/arm64
+            runs-on: ubuntu-24.04-arm
+            script: iculess-libxml2
+          - arch: x86_64
+            platform: linux/amd64
+            runs-on: ubuntu-24.04
+            script: iculess-qt6base
+          - arch: aarch64
+            platform: linux/arm64
+            runs-on: ubuntu-24.04-arm
+            script: iculess-qt6base
     container:
       image: ghcr.io/pkgforge-dev/archlinux:latest
     steps:
@@ -46,21 +62,40 @@ jobs:
       - name: build
         run: |
           sed -i 's/DownloadUser/#DownloadUser/g' /etc/pacman.conf
-          pacman -Syu --noconfirm base-devel strace patchelf curl wget \
-            desktop-file-utils git
           pacman -Syu --noconfirm \
+            alsa-lib \
+            base-devel \
             cmake \
-            ninja \
-            zlib \
-            zstd \
+            cups \
             curl \
-            libffi \
+            desktop-file-utils \
+            freetds \
+            git \
+            gst-plugins-base-libs \
+            gtk3 \
+            icu \
             libedit \
+            libfbclient \
+            libffi \
+            libpulse \
             libxml2 \
-            python-setuptools \
+            mariadb-libs \
+            ncurses \
+            ninja \
+            pacman \
+            patchelf \
+            postgresql \
+            python-myst-parser \
             python-psutil \
+            python-setuptools \
             python-sphinx \
-            python-myst-parser
+            readline \
+            strace \
+            unixodbc \
+            wget \
+            xmlstarlet \
+            zlib \
+            zstd
 
           sudo sed -i -e 's|-O2|-Os|' \
             -e 's|DEBUG_CFLAGS="-g"|DEBUG_CFLAGS="-g0"|' \
@@ -112,6 +147,22 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: llvm-nano-x86_64
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: iculess-libxml2-aarch64
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: iculess-libxml2-x86_64
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: iculess-qt6base-aarch64
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: iculess-qt6base-x86_64
 
       - name: release
         uses: marvinpinto/action-automatic-releases@v1.2.1

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -69,17 +69,25 @@ jobs:
             cups \
             curl \
             desktop-file-utils \
+            double-conversion \
             freetds \
             git \
             gst-plugins-base-libs \
             gtk3 \
             icu \
+            libb2 \
             libedit \
             libfbclient \
             libffi \
+            libice \
+            libinput \
             libpulse \
+            libsm \
+            libxkbcommon-x11 \
             libxml2 \
             mariadb-libs \
+            md4c \
+            mtdev \
             ncurses \
             ninja \
             pacman \
@@ -91,8 +99,16 @@ jobs:
             python-sphinx \
             readline \
             strace \
+            tslib \
             unixodbc \
+            vulkan-headers \
             wget \
+            xcb-util-cursor \
+            xcb-util-image \
+            xcb-util-keysyms \
+            xcb-util-renderutil \
+            xcb-util-wm \
+            xdg-utils \
             xmlstarlet \
             zlib \
             zstd

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -131,6 +131,7 @@ jobs:
           chmod +x ./*.sh
           sh ${{ matrix.script }}.sh
           mkdir ./dist
+          sha256sum ./*.pkg.tar.*
           mv ./*.pkg.tar.* ./dist
 
       - name: Upload artifact

--- a/iculess-libxml2.sh
+++ b/iculess-libxml2.sh
@@ -23,7 +23,8 @@ git clone https://gitlab.archlinux.org/archlinux/packaging/packages/libxml2.git 
 cd ./libxml2
 
 # remove the line that enables icu support
-sed -i '/--with-icu/d' ./PKGBUILD
+sed -i -e '/--with-icu/d' \
+	-e "s/x86_64/${ARCH}/" ./PKGBUILD
 cat ./PKGBUILD
 
 makepkg -f --skippgpcheck

--- a/iculess-libxml2.sh
+++ b/iculess-libxml2.sh
@@ -4,25 +4,24 @@ set -ex
 
 ARCH="$(uname -m)"
 
+git clone https://gitlab.archlinux.org/archlinux/packaging/packages/libxml2.git libxml2
+cd ./libxml2
+
+# remove the line that enables icu support
 case "${ARCH}" in
 	"x86_64")
 		EXT="zst"
+		sed -i '/--with-icu/d' ./PKGBUILD
 		;;
 	"aarch64")
 		EXT="xz"
+		sed -i "s/x86_64/${ARCH}/" ./PKGBUILD
 		;;
 	*)
 		echo "Unsupported Arch: '${ARCH}'"
 		exit 1
 		;;
 esac
-
-git clone https://gitlab.archlinux.org/archlinux/packaging/packages/libxml2.git libxml2
-cd ./libxml2
-
-# remove the line that enables icu support
-#sed -i -e '/--with-icu/d' \
-#	-e "s/x86_64/${ARCH}/" ./PKGBUILD
 cat ./PKGBUILD
 
 makepkg -f --skippgpcheck

--- a/iculess-libxml2.sh
+++ b/iculess-libxml2.sh
@@ -8,10 +8,11 @@ git clone https://gitlab.archlinux.org/archlinux/packaging/packages/libxml2.git 
 cd ./libxml2
 
 # remove the line that enables icu support
+sed -i '/--with-icu/d' ./PKGBUILD
+
 case "${ARCH}" in
 	"x86_64")
 		EXT="zst"
-		sed -i '/--with-icu/d' ./PKGBUILD
 		;;
 	"aarch64")
 		EXT="xz"

--- a/iculess-libxml2.sh
+++ b/iculess-libxml2.sh
@@ -6,11 +6,9 @@ ARCH="$(uname -m)"
 
 case "${ARCH}" in
 	"x86_64")
-		TARGETS_TO_BUILD="X86;AMDGPU"
 		EXT="zst"
 		;;
 	"aarch64")
-		TARGETS_TO_BUILD="AArch64;AMDGPU"
 		EXT="xz"
 		;;
 	*)
@@ -29,7 +27,7 @@ cat ./PKGBUILD
 
 makepkg -f --skippgpcheck
 ls -la
-rm -f libxml2-docs-*.pkg.tar.*
+rm -f ./libxml2-docs-*.pkg.tar.* ./libxml2-debug-*-x86_64.pkg.tar.* 
 mv ./libxml2-*.pkg.tar.${EXT} ../libxml2-iculess-${ARCH}.pkg.tar.${EXT}
 cd ..
 rm -rf ./libxml2

--- a/iculess-libxml2.sh
+++ b/iculess-libxml2.sh
@@ -21,8 +21,8 @@ git clone https://gitlab.archlinux.org/archlinux/packaging/packages/libxml2.git 
 cd ./libxml2
 
 # remove the line that enables icu support
-sed -i -e '/--with-icu/d' \
-	-e "s/x86_64/${ARCH}/" ./PKGBUILD
+#sed -i -e '/--with-icu/d' \
+#	-e "s/x86_64/${ARCH}/" ./PKGBUILD
 cat ./PKGBUILD
 
 makepkg -f --skippgpcheck

--- a/iculess-libxml2.sh
+++ b/iculess-libxml2.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -e
+set -ex
 
 ARCH="$(uname -m)"
 

--- a/iculess-qt6base.sh
+++ b/iculess-qt6base.sh
@@ -26,6 +26,9 @@ cd ./qt6-base
 sed -i -e "s/x86_64/${ARCH}/" \
 	-e 's/-DFEATURE_journald=ON/-DFEATURE_journald=OFF/' \
 	-e '/-DFEATURE_libproxy=ON \\/a\    -DFEATURE_icu=OFF \\' ./PKGBUILD
+if [ "${ARCH}" = "aarch64" ]; then
+	sed -i '/-DFEATURE_no_direct_extern_access=ON/d' ./PKGBUILD
+fi
 cat ./PKGBUILD
 
 makepkg -f --skippgpcheck

--- a/iculess-qt6base.sh
+++ b/iculess-qt6base.sh
@@ -24,7 +24,7 @@ cd ./qt6-base
 
 # remove the line that enables icu support
 sed -i -e "s/x86_64/${ARCH}/" \
-	's/-DFEATURE_journald=ON/-DFEATURE_journald=OFF/' \
+	-e 's/-DFEATURE_journald=ON/-DFEATURE_journald=OFF/' \
 	-e '/-DFEATURE_libproxy=ON \\/a\    -DFEATURE_icu=OFF \\' ./PKGBUILD
 cat ./PKGBUILD
 

--- a/iculess-qt6base.sh
+++ b/iculess-qt6base.sh
@@ -4,21 +4,6 @@ set -e
 
 ARCH="$(uname -m)"
 
-case "${ARCH}" in
-	"x86_64")
-		TARGETS_TO_BUILD="X86;AMDGPU"
-		EXT="zst"
-		;;
-	"aarch64")
-		TARGETS_TO_BUILD="AArch64;AMDGPU"
-		EXT="xz"
-		;;
-	*)
-		echo "Unsupported Arch: '${ARCH}'"
-		exit 1
-		;;
-esac
-
 git clone https://gitlab.archlinux.org/archlinux/packaging/packages/qt6-base qt6-base
 cd ./qt6-base
 
@@ -26,14 +11,26 @@ cd ./qt6-base
 sed -i -e "s/x86_64/${ARCH}/" \
 	-e 's/-DFEATURE_journald=ON/-DFEATURE_journald=OFF/' \
 	-e '/-DFEATURE_libproxy=ON \\/a\    -DFEATURE_icu=OFF \\' ./PKGBUILD
-if [ "${ARCH}" = "aarch64" ]; then
-	sed -i '/-DFEATURE_no_direct_extern_access=ON/d' ./PKGBUILD
-fi
+
+case "${ARCH}" in
+	"x86_64")
+		EXT="zst"
+		;;
+	"aarch64")
+		EXT="xz"
+		sed -i 's/-DFEATURE_no_direct_extern_access=ON/-DQT_FEATURE_sql_ibase=OFF/' ./PKGBUILD
+		;;
+	*)
+		echo "Unsupported Arch: '${ARCH}'"
+		exit 1
+		;;
+esac
+
 cat ./PKGBUILD
 
 makepkg -f --skippgpcheck
 ls -la
-rm -f qt6-base-docs-*.pkg.tar.*
+rm -f qt6-base-docs-*.pkg.tar.* qt6-base-debug-*.pkg.tar.*
 mv ./qt6-base-*.pkg.tar.${EXT} ../qt6-base-iculess-${ARCH}.pkg.tar.${EXT}
 cd ..
 rm -rf ./qt6-base

--- a/iculess-qt6base.sh
+++ b/iculess-qt6base.sh
@@ -23,7 +23,8 @@ git clone https://gitlab.archlinux.org/archlinux/packaging/packages/qt6-base qt6
 cd ./qt6-base
 
 # remove the line that enables icu support
-sed -i -e 's/-DFEATURE_journald=ON/-DFEATURE_journald=OFF/' \
+sed -i -e "s/x86_64/${ARCH}/" \
+	's/-DFEATURE_journald=ON/-DFEATURE_journald=OFF/' \
 	-e '/-DFEATURE_libproxy=ON \\/a\    -DFEATURE_icu=OFF \\' ./PKGBUILD
 cat ./PKGBUILD
 

--- a/iculess-qt6base.sh
+++ b/iculess-qt6base.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -e
+set -ex
 
 ARCH="$(uname -m)"
 
@@ -30,7 +30,7 @@ cat ./PKGBUILD
 
 makepkg -f --skippgpcheck
 ls -la
-rm -f qt6-base-docs-*.pkg.tar.* qt6-base-debug-*.pkg.tar.*
+rm -fv qt6-base-docs-*.pkg.tar.* qt6-base-debug-*.pkg.tar.*
 mv ./qt6-base-*.pkg.tar.${EXT} ../qt6-base-iculess-${ARCH}.pkg.tar.${EXT}
 cd ..
 rm -rf ./qt6-base


### PR DESCRIPTION
This removes the 30 MiB libicudata lib dependency, which is rarely needed. 