### PR TITLE
add ffmpeg mini

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -100,6 +100,7 @@ jobs:
             ninja \
             pacman \
             patchelf \
+            perl \
             postgresql \
             python-myst-parser \
             python-psutil \

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -130,6 +130,8 @@ jobs:
             nasm \
             opencl-headers
 
+          export PATH="$PATH:/usr/bin/core_perl"
+
           sudo sed -i -e 's|-O2|-Os|' \
             -e 's|DEBUG_CFLAGS="-g"|DEBUG_CFLAGS="-g0"|' \
             -e 's|-fno-omit-frame-pointer|-fomit-frame-pointer|' \

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -52,6 +52,14 @@ jobs:
             platform: linux/arm64
             runs-on: ubuntu-24.04-arm
             script: iculess-qt6base
+          - arch: x86_64
+            platform: linux/amd64
+            runs-on: ubuntu-24.04
+            script: ffmpeg-mini
+          - arch: aarch64
+            platform: linux/arm64
+            runs-on: ubuntu-24.04-arm
+            script: ffmpeg-mini
     container:
       image: ghcr.io/pkgforge-dev/archlinux:latest
     steps:
@@ -111,7 +119,15 @@ jobs:
             xdg-utils \
             xmlstarlet \
             zlib \
-            zstd
+            zstd \
+            amf-headers \
+            avisynthplus \
+            clang \
+            ffnvcodec-headers \
+            frei0r-plugins \
+            ladspa \
+            nasm \
+            opencl-headers
 
           sudo sed -i -e 's|-O2|-Os|' \
             -e 's|DEBUG_CFLAGS="-g"|DEBUG_CFLAGS="-g0"|' \
@@ -180,6 +196,14 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: iculess-qt6base-x86_64
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ffmpeg-mini-aarch64
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ffmpeg-mini-x86_64
 
       - name: release
         uses: marvinpinto/action-automatic-releases@v1.2.1

--- a/ffmpeg-mini.sh
+++ b/ffmpeg-mini.sh
@@ -75,7 +75,7 @@ cat ./PKGBUILD
 makepkg -f --skippgpcheck
 ls -la
 rm -f ./ffmpeg-docs-*.pkg.tar.* ./ffmpeg-debug-*.pkg.tar.*
-mv ./ffmpeg-*.pkg.tar.${EXT} ../ffmpeg-x265less-${ARCH}.pkg.tar.${EXT}
+mv ./ffmpeg-*.pkg.tar.${EXT} ../ffmpeg-mini-${ARCH}.pkg.tar.${EXT}
 cd ..
 rm -rf ./ffmpeg
 echo "All done!"

--- a/ffmpeg-mini.sh
+++ b/ffmpeg-mini.sh
@@ -74,7 +74,7 @@ cat ./PKGBUILD
 
 makepkg -f --skippgpcheck
 ls -la
-rm -f ./ffmpeg-docs-*.pkg.tar.* ./ffmpeg-debug-*-x86_64.pkg.tar.*
+rm -f ./ffmpeg-docs-*.pkg.tar.* ./ffmpeg-debug-*.pkg.tar.*
 mv ./ffmpeg-*.pkg.tar.${EXT} ../ffmpeg-x265less-${ARCH}.pkg.tar.${EXT}
 cd ..
 rm -rf ./ffmpeg

--- a/ffmpeg-mini.sh
+++ b/ffmpeg-mini.sh
@@ -2,6 +2,50 @@
 
 set -ex
 
+sudo pacman -S --noconfirm \
+  aom \
+  glslang \
+  gsm \
+  jack \
+  libass \
+  libavc1394 \
+  libbluray \
+  libbs2b \
+  libdvdnav \
+  libdvdread \
+  libiec61883 \
+  libjxl \
+  libmodplug \
+  libopenmpt \
+  libplacebo \
+  libraw1394 \
+  libsoxr \
+  libssh \
+  libtheora \
+  libva \
+  libvdpau \
+  libvpx \
+  libwebp \
+  ocl-icd \
+  onevpl \
+  opencore-amr \
+  rav1e \
+  rubberband \
+  sdl2 \
+  snappy \
+  speex \
+  srt \
+  svt-av1 \
+  v4l-utils \
+  vapoursynth \
+  vid.stab \
+  vmaf \
+  vulkan-icd-loader \
+  x264 \
+  xvidcore \
+  zeromq \
+  zimg
+
 ARCH="$(uname -m)"
 case "${ARCH}" in
 	"x86_64")

--- a/ffmpeg-mini.sh
+++ b/ffmpeg-mini.sh
@@ -35,11 +35,9 @@ sudo pacman -S --noconfirm \
   snappy \
   speex \
   srt \
-  svt-av1 \
   v4l-utils \
   vapoursynth \
   vid.stab \
-  vmaf \
   vulkan-icd-loader \
   x264 \
   xvidcore \
@@ -50,6 +48,7 @@ ARCH="$(uname -m)"
 case "${ARCH}" in
 	"x86_64")
 		EXT="zst"
+		sudo pacman -S --noconfirm svt-av1 vmaf
 		git clone https://gitlab.archlinux.org/archlinux/packaging/packages/ffmpeg.git ffmpeg
 		cd ./ffmpeg
 		;;

--- a/ffmpeg-mini.sh
+++ b/ffmpeg-mini.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -ex
+
+ARCH="$(uname -m)"
+case "${ARCH}" in
+	"x86_64")
+		EXT="zst"
+		git clone https://gitlab.archlinux.org/archlinux/packaging/packages/ffmpeg.git ffmpeg
+		cd ./ffmpeg
+		;;
+	"aarch64")
+		EXT="xz"
+		git clone https://raw.githubusercontent.com/archlinuxarm/PKGBUILDs/refs/heads/master/extra/ffmpeg/PKGBUILD ffmpeg
+		cd ./ffmpeg
+		sed -i "s/x86_64/${ARCH}/" ./PKGBUILD
+		;;
+	*)
+		echo "Unsupported Arch: '${ARCH}'"
+		exit 1
+		;;
+esac
+
+# remove x265 support and AV1 encoding support
+sed -i -e '/x265/d' \
+	-e '/librav1e/d' \
+	-e '/--enable-libsvtav1/d' ./PKGBUILD
+
+cat ./PKGBUILD
+
+makepkg -f --skippgpcheck
+ls -la
+rm -f ./ffmpeg-docs-*.pkg.tar.* ./ffmpeg-debug-*-x86_64.pkg.tar.*
+mv ./ffmpeg-*.pkg.tar.${EXT} ../ffmpeg-x265less-${ARCH}.pkg.tar.${EXT}
+cd ..
+rm -rf ./ffmpeg
+echo "All done!"

--- a/ffmpeg-mini.sh
+++ b/ffmpeg-mini.sh
@@ -54,7 +54,8 @@ case "${ARCH}" in
 		;;
 	"aarch64")
 		EXT="xz"
-		git clone https://raw.githubusercontent.com/archlinuxarm/PKGBUILDs/refs/heads/master/extra/ffmpeg/PKGBUILD ffmpeg
+		git clone --depth 1 https://github.com/archlinuxarm/PKGBUILDs.git PKGBUILDs
+		mv ./PKGBUILDs/extra/ffmpeg ./
 		cd ./ffmpeg
 		sed -i "s/x86_64/${ARCH}/" ./PKGBUILD
 		;;

--- a/iculess-libxml2.sh
+++ b/iculess-libxml2.sh
@@ -4,31 +4,51 @@ set -ex
 
 ARCH="$(uname -m)"
 
-git clone https://gitlab.archlinux.org/archlinux/packaging/packages/libxml2.git libxml2
-cd ./libxml2
+_build_libxml2() (
+	git clone https://gitlab.archlinux.org/archlinux/packaging/packages/libxml2.git libxml2
+	cd ./libxml2
+	
+	# remove the line that enables icu support
+	sed -i '/--with-icu/d' ./PKGBUILD
+	
+	case "${ARCH}" in
+		"x86_64")
+			EXT="zst"
+			;;
+		"aarch64")
+			EXT="xz"
+			sed -i "s/x86_64/${ARCH}/" ./PKGBUILD
+			;;
+		*)
+			echo "Unsupported Arch: '${ARCH}'"
+			exit 1
+			;;
+	esac
+	cat ./PKGBUILD
+	
+	makepkg -f --skippgpcheck
+	ls -la
+	rm -f ./libxml2-docs-*.pkg.tar.* ./libxml2-debug-*-x86_64.pkg.tar.* 
+	mv ./libxml2-*.pkg.tar.${EXT} ../libxml2-iculess-${ARCH}.pkg.tar.${EXT}
+	cd ..
+	rm -rf ./libxml2
+)
 
-# remove the line that enables icu support
-sed -i '/--with-icu/d' ./PKGBUILD
+COUNT=0
+while [ "$COUNT" -le 5 ]; do
+    if ! _build_libxml2; then
+        rm -rf ./libxml2 || true
+        COUNT=$((COUNT + 1))
+	echo "Failed, trying $COUNT time"
+    else
+        break
+    fi
+done
 
-case "${ARCH}" in
-	"x86_64")
-		EXT="zst"
-		;;
-	"aarch64")
-		EXT="xz"
-		sed -i "s/x86_64/${ARCH}/" ./PKGBUILD
-		;;
-	*)
-		echo "Unsupported Arch: '${ARCH}'"
-		exit 1
-		;;
-esac
-cat ./PKGBUILD
+if [ "$COUNT" -gt 5 ]; then
+	echo "Failed to build libxml2 5 times"
+	exit 1
+fi
 
-makepkg -f --skippgpcheck
-ls -la
-rm -f ./libxml2-docs-*.pkg.tar.* ./libxml2-debug-*-x86_64.pkg.tar.* 
-mv ./libxml2-*.pkg.tar.${EXT} ../libxml2-iculess-${ARCH}.pkg.tar.${EXT}
-cd ..
-rm -rf ./libxml2
+	
 echo "All done!"

--- a/iculess-libxml2.sh
+++ b/iculess-libxml2.sh
@@ -1,16 +1,17 @@
 #!/bin/sh
 
-set -ex
+set -x
 
 ARCH="$(uname -m)"
 
 _build_libxml2() (
+	rm -rf ./libxml2 || true
 	git clone https://gitlab.archlinux.org/archlinux/packaging/packages/libxml2.git libxml2
 	cd ./libxml2
-	
+
 	# remove the line that enables icu support
 	sed -i '/--with-icu/d' ./PKGBUILD
-	
+
 	case "${ARCH}" in
 		"x86_64")
 			EXT="zst"
@@ -25,24 +26,23 @@ _build_libxml2() (
 			;;
 	esac
 	cat ./PKGBUILD
-	
-	makepkg -f --skippgpcheck
+
+	makepkg -f --skippgpcheck || return 1
 	ls -la
-	rm -f ./libxml2-docs-*.pkg.tar.* ./libxml2-debug-*-x86_64.pkg.tar.* 
-	mv ./libxml2-*.pkg.tar.${EXT} ../libxml2-iculess-${ARCH}.pkg.tar.${EXT}
+	rm -f ./libxml2-docs-*.pkg.tar.* ./libxml2-debug-*-x86_64.pkg.tar.*
+	mv ./libxml2-*.pkg.tar.${EXT} ../libxml2-iculess-${ARCH}.pkg.tar.${EXT} || return 1
 	cd ..
 	rm -rf ./libxml2
 )
 
 COUNT=0
 while [ "$COUNT" -le 5 ]; do
-    if ! _build_libxml2; then
-        rm -rf ./libxml2 || true
-        COUNT=$((COUNT + 1))
-	echo "Failed, trying $COUNT time"
-    else
-        break
-    fi
+	if ! _build_libxml2; then
+		COUNT=$((COUNT + 1))
+		echo "Failed, trying $COUNT time"
+	else
+		break
+	fi
 done
 
 if [ "$COUNT" -gt 5 ]; then
@@ -50,5 +50,5 @@ if [ "$COUNT" -gt 5 ]; then
 	exit 1
 fi
 
-	
+
 echo "All done!"


### PR DESCRIPTION
This version of ffmpeg primarily removes linking to libx265, which is a 20 MiB lib that is rarely used since most software uses x264, VP9 and lately AV1.

