### PR TITLE
upstream was broken indeed

### DIFF
--- a/ffmpeg-mini.sh
+++ b/ffmpeg-mini.sh
@@ -67,7 +67,6 @@ esac
 
 # remove x265 support and AV1 encoding support
 sed -i -e '/x265/d' \
-	-e '/libv4l2/d' \
 	-e '/librav1e/d' \
 	-e 's/--enable-libsvtav1/--enable-small/' \
 	-e '/--enable-vapoursynth/d' ./PKGBUILD


### PR DESCRIPTION
@VHSgunzo

https://gitlab.archlinux.org/archlinux/packaging/packages/ffmpeg/-/commit/1e27244932c2c61ab340b357ff4ac8dd0065e3af

I have no idea how you were able to build it in clean chroot before. 