### PR TITLE
It is now possible to build mesa without linking to `libLLVM.so`!

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -80,6 +80,14 @@ jobs:
           - arch: x86_64
             platform: linux/amd64
             runs-on: ubuntu-24.04
+            script: mesa-nano
+          - arch: aarch64
+            platform: linux/arm64
+            runs-on: ubuntu-24.04-arm
+            script: mesa-nano
+          - arch: x86_64
+            platform: linux/amd64
+            runs-on: ubuntu-24.04
             script: mangohud-pythonless
           - arch: aarch64
             platform: linux/arm64
@@ -244,6 +252,14 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: mesa-mini-x86_64
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: mesa-nano-aarch64
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: mesa-nano-x86_64
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -142,7 +142,7 @@ jobs:
 
           export PATH="$PATH:/usr/bin/core_perl"
 
-          sudo sed -i -e 's|-O2|-Os|' \
+          sudo sed -i \
             -e 's|DEBUG_CFLAGS="-g"|DEBUG_CFLAGS="-g0"|' \
             -e 's|-fno-omit-frame-pointer|-fomit-frame-pointer|' \
             -e 's|-mno-omit-leaf-frame-pointer||' \

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repo makes modified versiones of some Archlinux packages, these are intended for AppImages to reduce final size:
 
+* `mesa-mini` and `vulkan-{radeon,intel,etc}-mini` **Mesa that does not link to `libLLVM.so`**, making any hardware accelerated app tiny as result.
+
+* `mesa-nano` and `vulkan-{radeon,intel,etc}-nano` similar to `mesa-mini`, built with -Oz which makes it ~30% smaller, note -Oz can have a performance and even stability issue so do not use this package in apps like emulators where this is critical.
+
 * `llvm-libs-mini` and `llmv-libs-nano`, smaller versions of `libLLVM.so` which is a 130+ MiB library that Archlinux compiles with support for a lot of architectures (`arm`, `aarch64`, `risv`, etc), the mini version should be a drop in replacment that is unlikely to cause any issue, while the nano version only ships the host target (`x86_64` or `aarch64`) + `AMDGPU`.
 
 * iculess versions of `libxml2` and `qt6-base`, normally these packages depend on a 30 MiB libicudata lib that is rarely needed, using them gets rid of said library.
@@ -9,8 +13,6 @@ This repo makes modified versiones of some Archlinux packages, these are intende
 * `ffmpeg-mini` which mainly removes linking to libx265.so, which is a 20 MiB library that is rarely needed, using it gets rid of said library.
 
 * `opus-nano` I have no idea why Archlinux makes this lib 5 MiB when both ubuntu and alpine make it <500 KiB
-
-* `mesa-mini` which makes several packages (`mesa`, `vulkan-{radeon, intel, etc}`) ~30% smaller.
 
 # Projects using these packages
 

--- a/ffmpeg-mini.sh
+++ b/ffmpeg-mini.sh
@@ -3,6 +3,9 @@
 set -ex
 
 ARCH="$(uname -m)"
+
+sed -i -e 's|-O2|-Oz|' /etc/makepkg.conf
+
 case "${ARCH}" in
 	"x86_64")
 		EXT="zst"

--- a/iculess-libxml2.sh
+++ b/iculess-libxml2.sh
@@ -4,7 +4,7 @@ set -x
 
 ARCH="$(uname -m)"
 
-sed -i -e 's|-O2|-Os|' /etc/makepkg.conf
+sed -i -e 's|-O2|-Oz|' /etc/makepkg.conf
 
 _build_libxml2() (
 	rm -rf ./libxml2 || true

--- a/iculess-libxml2.sh
+++ b/iculess-libxml2.sh
@@ -4,6 +4,8 @@ set -x
 
 ARCH="$(uname -m)"
 
+sed -i -e 's|-O2|-Os|' /etc/makepkg.conf
+
 _build_libxml2() (
 	rm -rf ./libxml2 || true
 	git clone https://gitlab.archlinux.org/archlinux/packaging/packages/libxml2.git libxml2

--- a/iculess-qt6base.sh
+++ b/iculess-qt6base.sh
@@ -4,6 +4,8 @@ set -ex
 
 ARCH="$(uname -m)"
 
+sed -i -e 's|-O2|-Oz|' /etc/makepkg.conf
+
 git clone https://gitlab.archlinux.org/archlinux/packaging/packages/qt6-base qt6-base
 cd ./qt6-base
 

--- a/intel-media-mini.sh
+++ b/intel-media-mini.sh
@@ -4,6 +4,8 @@ set -ex
 
 ARCH="$(uname -m)"
 
+sed -i -e 's|-O2|-Os|' /etc/makepkg.conf
+
 git clone https://gitlab.archlinux.org/archlinux/packaging/packages/intel-media-driver.git ./intel-media-driver
 cd ./intel-media-driver
 

--- a/llvm-mini.sh
+++ b/llvm-mini.sh
@@ -4,6 +4,8 @@ set -e
 
 ARCH="$(uname -m)"
 
+sed -i -e 's|-O2|-Oz|' /etc/makepkg.conf
+
 git clone https://gitlab.archlinux.org/archlinux/packaging/packages/llvm llvm
 cd ./llvm
 

--- a/llvm-nano.sh
+++ b/llvm-nano.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-export ARCH="$(uname -m)"
+ARCH="$(uname -m)"
+
+sed -i -e 's|-O2|-Oz|' /etc/makepkg.conf
 
 git clone https://gitlab.archlinux.org/archlinux/packaging/packages/llvm llvm
 cd ./llvm

--- a/mangohud-pythonless.sh
+++ b/mangohud-pythonless.sh
@@ -4,6 +4,8 @@ set -ex
 
 ARCH="$(uname -m)"
 
+sed -i -e 's|-O2|-Oz|' /etc/makepkg.conf
+
 git clone https://github.com/VHSgunzo/mangohud-PKGBUILD.git ./mangohud-temp
 mv -v ./mangohud-temp/mangohud ./
 rm -rf ./mangohud-temp

--- a/mesa-mini.sh
+++ b/mesa-mini.sh
@@ -45,7 +45,7 @@ sed -i \
 	-e 's/gallium-rusticl=true/gallium-rusticl=false/' \
 	-e 's/valgrind=enabled/valgrind=disabled/'         \
 	-e 's/-D video-codecs=all/-D video-codecs=all -D amd-use-llvm=false -D draw-use-llvm=false/' \
-	-e 's/-g1/-g0 -Os/g' ./PKGBUILD
+	-e 's/-g1/-g0/g' ./PKGBUILD
 
 cat ./PKGBUILD
 

--- a/mesa-mini.sh
+++ b/mesa-mini.sh
@@ -28,7 +28,10 @@ esac
 sed -i -e "s/x86_64/${ARCH}/" ./PKGBUILD
 
 # debloat mesa
-sed -i -e 's/r300,//'      \
+sed -i \
+	-e 's/vulkan-swrast//' \
+	-e 's/opencl-mesa//'   \
+	-e 's/r300,//'         \
 	-e 's/r600,//'         \
 	-e 's/svga,//'         \
 	-e 's/softpipe,//'     \

--- a/mesa-mini.sh
+++ b/mesa-mini.sh
@@ -29,6 +29,7 @@ sed -i -e "s/x86_64/${ARCH}/" ./PKGBUILD
 
 # debloat mesa
 sed -i \
+	-e '/llvm-libs/d'      \
 	-e 's/vulkan-swrast//' \
 	-e 's/opencl-mesa//'   \
 	-e 's/r300,//'         \

--- a/mesa-mini.sh
+++ b/mesa-mini.sh
@@ -32,7 +32,7 @@ sed -i -e 's/r300,//'      \
 	-e 's/svga,//'         \
 	-e 's/softpipe,//'     \
 	-e 's/llvmpipe,//'     \
-	-e 's/swrast//'        \
+	-e 's/swrast,//'       \
 	-e '/sysprof/d'        \
 	-e '/_pick vkswrast/d' \
 	-e '/_pick opencl/d'   \

--- a/mesa-mini.sh
+++ b/mesa-mini.sh
@@ -39,7 +39,7 @@ sed -i -e 's/r300,//'      \
 	-e 's/intel-rt=enabled/intel-rt=disabled/'         \
 	-e 's/gallium-rusticl=true/gallium-rusticl=false/' \
 	-e 's/valgrind=enabled/valgrind=disabled/'         \
-	-e 's/-D video-codecs=all/-D video-codecs=all -D amd-use-llvm=false -D draw-use-llvm=false/'
+	-e 's/-D video-codecs=all/-D video-codecs=all -D amd-use-llvm=false -D draw-use-llvm=false/' \
 	-e 's/-g1/-g0 -Os/g' ./PKGBUILD
 
 cat ./PKGBUILD

--- a/mesa-mini.sh
+++ b/mesa-mini.sh
@@ -28,11 +28,18 @@ esac
 sed -i -e "s/x86_64/${ARCH}/" ./PKGBUILD
 
 # debloat mesa
-sed -i -e 's/r300,//'  \
-	-e 's/svga,//'     \
-	-e 's/softpipe,//' \
-	-e '/sysprof/d'    \
-	-e 's/valgrind=enabled/valgrind=disabled/'   \
+sed -i -e 's/r300,//'      \
+	-e 's/svga,//'         \
+	-e 's/softpipe,//'     \
+	-e 's/llvmpipe,//'     \
+	-e 's/swrast//'        \
+	-e '/sysprof/d'        \
+	-e '/_pick vkswrast/d' \
+	-e '/_pick opencl/d'   \
+	-e 's/intel-rt=enabled/intel-rt=disabled/'         \
+	-e 's/gallium-rusticl=true/gallium-rusticl=false/' \
+	-e 's/valgrind=enabled/valgrind=disabled/'         \
+	-e 's/-D video-codecs=all/-D video-codecs=all -D amd-use-llvm=false -D draw-use-llvm=false/'
 	-e 's/-g1/-g0 -Os/g' ./PKGBUILD
 
 cat ./PKGBUILD

--- a/mesa-mini.sh
+++ b/mesa-mini.sh
@@ -29,6 +29,7 @@ sed -i -e "s/x86_64/${ARCH}/" ./PKGBUILD
 
 # debloat mesa
 sed -i -e 's/r300,//'      \
+	-e 's/r600,//'         \
 	-e 's/svga,//'         \
 	-e 's/softpipe,//'     \
 	-e 's/llvmpipe,//'     \

--- a/mesa-nano.sh
+++ b/mesa-nano.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+set -ex
+
+ARCH="$(uname -m)"
+
+case "${ARCH}" in
+	"x86_64")
+		EXT="zst"
+		git clone https://gitlab.archlinux.org/archlinux/packaging/packages/mesa.git ./mesa
+		cd ./mesa
+		;;
+	"aarch64")
+		EXT="xz"
+		git clone https://github.com/archlinuxarm/PKGBUILDs ./mesa
+		cd ./mesa
+		mv -v ./extra/mesa/* ./extra/mesa/.* ./
+
+		# FIX THIS WHOLE MESS
+		sed -i 's|https://mesa.freedesktop.org/archive/mesa|https://archive.mesa3d.org/mesa|' ./PKGBUILD
+		;;
+	*)
+		echo "Unsupported Arch: '${ARCH}'"
+		exit 1
+		;;
+esac
+
+sed -i -e "s/x86_64/${ARCH}/" ./PKGBUILD
+
+# debloat mesa
+sed -i \
+	-e '/llvm-libs/d'      \
+	-e 's/vulkan-swrast//' \
+	-e 's/opencl-mesa//'   \
+	-e 's/r300,//'         \
+	-e 's/r600,//'         \
+	-e 's/svga,//'         \
+	-e 's/softpipe,//'     \
+	-e 's/llvmpipe,//'     \
+	-e 's/swrast,//'       \
+	-e '/sysprof/d'        \
+	-e '/_pick vkswrast/d' \
+	-e '/_pick opencl/d'   \
+	-e 's/intel-rt=enabled/intel-rt=disabled/'         \
+	-e 's/gallium-rusticl=true/gallium-rusticl=false/' \
+	-e 's/valgrind=enabled/valgrind=disabled/'         \
+	-e 's/-D video-codecs=all/-D video-codecs=all -D amd-use-llvm=false -D draw-use-llvm=false/' \
+	-e 's/-g1/-g0 -Oz/g' ./PKGBUILD
+
+cat ./PKGBUILD
+
+makepkg -fs --noconfirm --skippgpcheck
+ls -la
+rm -fv *-docs-*.pkg.tar.* *-debug-*.pkg.tar.*
+mv -v ./mesa-*.pkg.tar.${EXT}           ../mesa-nano-${ARCH}.pkg.tar.${EXT}
+mv -v ./vulkan-radeon-*.pkg.tar.${EXT}  ../vulkan-radeon-nano-${ARCH}.pkg.tar.${EXT}
+mv -v ./vulkan-nouveau-*.pkg.tar.${EXT} ../vulkan-nouveau-nano-${ARCH}.pkg.tar.${EXT}
+
+if [ "$ARCH" = 'x86_64' ]; then
+	mv -v ./vulkan-intel-*.pkg.tar.${EXT} ../vulkan-intel-nano-${ARCH}.pkg.tar.${EXT}
+else
+	mv -v ./vulkan-broadcom-*.pkg.tar.${EXT}  ../vulkan-broadcom-nano-${ARCH}.pkg.tar.${EXT}
+	mv -v ./vulkan-panfrost-*.pkg.tar.${EXT}  ../vulkan-panfrost-nano-${ARCH}.pkg.tar.${EXT}
+	mv -v ./vulkan-freedreno-*.pkg.tar.${EXT} ../vulkan-freedreno-nano-${ARCH}.pkg.tar.${EXT}
+fi
+cd ..
+rm -rf ./mesa
+echo "All done!"
+

--- a/mesa-nano.sh
+++ b/mesa-nano.sh
@@ -4,6 +4,8 @@ set -ex
 
 ARCH="$(uname -m)"
 
+sed -i -e 's|-O2|-Oz|' /etc/makepkg.conf
+
 case "${ARCH}" in
 	"x86_64")
 		EXT="zst"

--- a/opus-nano.sh
+++ b/opus-nano.sh
@@ -4,6 +4,8 @@ set -ex
 
 ARCH="$(uname -m)"
 
+sed -i -e 's|-O2|-Oz|' /etc/makepkg.conf
+
 git clone https://gitlab.archlinux.org/archlinux/packaging/packages/opus.git ./opus
 cd ./opus
 


### PR DESCRIPTION
https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/28969

mesa packages have also been split into two. 

* `mesa-mini` does not link to `libLLVM.so` and a few other changes, intended to be a drop in replacement.

* `mesa-nano` it is 30% smaller as well, however this is achieved by building with -Oz, which I have seen causing bugs in citron before, so only use this one as long as it does not cause issues. 


fixes #9 finally!