### PR TITLE
add svga driver back and add `vulkan-asahi`

### DIFF
--- a/mesa-mini.sh
+++ b/mesa-mini.sh
@@ -33,7 +33,6 @@ sed -i \
 	-e 's/opencl-mesa//'   \
 	-e 's/r300,//'         \
 	-e 's/r600,//'         \
-	-e 's/svga,//'         \
 	-e 's/softpipe,//'     \
 	-e 's/llvmpipe,//'     \
 	-e 's/swrast,//'       \

--- a/mesa-mini.sh
+++ b/mesa-mini.sh
@@ -11,6 +11,7 @@ case "$ARCH" in
 		cd ./mesa
 		# remove aarch64 drivers from x86_64
 		sed -i \
+			-e '/_pick vkasahi/d' \
 			-e 's/vulkan-asahi//' \
 			-e 's/,asahi//g'      \
 			-e 's/,freedreno//g'  \

--- a/mesa-mini.sh
+++ b/mesa-mini.sh
@@ -11,10 +11,11 @@ case "$ARCH" in
 		cd ./mesa
 		# remove aarch64 drivers from x86_64
 		sed -i \
-			-e '/_pick vkasahi/d' \
-			-e 's/vulkan-asahi//' \
-			-e 's/,asahi//g'      \
-			-e 's/,freedreno//g'  \
+			-e '/_pick vkfdreno/d' \
+			-e '/_pick vkasahi/d'  \
+			-e 's/vulkan-asahi//'  \
+			-e 's/,asahi//g'       \
+			-e 's/,freedreno//g'   \
 			./PKGBUILD
 		;;
 	aarch64)

--- a/mesa-mini.sh
+++ b/mesa-mini.sh
@@ -9,6 +9,11 @@ case "$ARCH" in
 		EXT=zst
 		git clone --depth 1 https://gitlab.archlinux.org/archlinux/packaging/packages/mesa.git ./mesa
 		cd ./mesa
+		# remove aarch64 drivers from x86_64
+		sed -i \
+			-e 's/,asahi//g'     \
+			-e 's/,freedreno//g' \
+			./PKGBUILD
 		;;
 	aarch64)
 		EXT=xz
@@ -60,6 +65,7 @@ elif [ "$ARCH" = 'aarch64' ]; then
 	mv -v ./vulkan-broadcom-*.pkg.tar."$EXT"  ../vulkan-broadcom-mini-"$ARCH".pkg.tar."$EXT"
 	mv -v ./vulkan-panfrost-*.pkg.tar."$EXT"  ../vulkan-panfrost-mini-"$ARCH".pkg.tar."$EXT"
 	mv -v ./vulkan-freedreno-*.pkg.tar."$EXT" ../vulkan-freedreno-mini-"$ARCH".pkg.tar."$EXT"
+	mv -v ./vulkan-asahi-*.pkg.tar."$EXT"     ../vulkan-asahi-mini-"$ARCH".pkg.tar."$EXT"
 fi
 
 cd ..

--- a/mesa-mini.sh
+++ b/mesa-mini.sh
@@ -11,11 +11,12 @@ case "$ARCH" in
 		cd ./mesa
 		# remove aarch64 drivers from x86_64
 		sed -i \
-			-e '/_pick vkfdreno/d' \
-			-e '/_pick vkasahi/d'  \
-			-e 's/vulkan-asahi//'  \
-			-e 's/,asahi//g'       \
-			-e 's/,freedreno//g'   \
+			-e '/_pick vkfdreno/d'    \
+			-e '/_pick vkasahi/d'     \
+			-e 's/vulkan-freedreno//' \
+			-e 's/vulkan-asahi//'     \
+			-e 's/,asahi//g'          \
+			-e 's/,freedreno//g'      \
 			./PKGBUILD
 		;;
 	aarch64)

--- a/mesa-mini.sh
+++ b/mesa-mini.sh
@@ -11,8 +11,9 @@ case "$ARCH" in
 		cd ./mesa
 		# remove aarch64 drivers from x86_64
 		sed -i \
-			-e 's/,asahi//g'     \
-			-e 's/,freedreno//g' \
+			-e 's/vulkan-asahi//' \
+			-e 's/,asahi//g'      \
+			-e 's/,freedreno//g'  \
 			./PKGBUILD
 		;;
 	aarch64)

--- a/mesa-nano.sh
+++ b/mesa-nano.sh
@@ -35,7 +35,6 @@ sed -i \
 	-e 's/opencl-mesa//'   \
 	-e 's/r300,//'         \
 	-e 's/r600,//'         \
-	-e 's/svga,//'         \
 	-e 's/softpipe,//'     \
 	-e 's/llvmpipe,//'     \
 	-e 's/swrast,//'       \

--- a/mesa-nano.sh
+++ b/mesa-nano.sh
@@ -11,6 +11,11 @@ case "$ARCH" in
 		EXT=zst
 		git clone --depth 1 https://gitlab.archlinux.org/archlinux/packaging/packages/mesa.git ./mesa
 		cd ./mesa
+		# remove aarch64 drivers from x86_64
+		sed -i \
+			-e 's/,asahi//g'     \
+			-e 's/,freedreno//g' \
+			./PKGBUILD
 		;;
 	aarch64)
 		EXT=xz
@@ -62,6 +67,7 @@ elif [ "$ARCH" = 'aarch64' ]; then
 	mv -v ./vulkan-broadcom-*.pkg.tar."$EXT"  ../vulkan-broadcom-nano-"$ARCH".pkg.tar."$EXT"
 	mv -v ./vulkan-panfrost-*.pkg.tar."$EXT"  ../vulkan-panfrost-nano-"$ARCH".pkg.tar."$EXT"
 	mv -v ./vulkan-freedreno-*.pkg.tar."$EXT" ../vulkan-freedreno-nano-"$ARCH".pkg.tar."$EXT"
+	mv -v ./vulkan-asahi-*.pkg.tar."$EXT"     ../vulkan-asahi-nano-"$ARCH".pkg.tar."$EXT"
 fi
 
 cd ..

--- a/mesa-nano.sh
+++ b/mesa-nano.sh
@@ -13,10 +13,11 @@ case "$ARCH" in
 		cd ./mesa
 		# remove aarch64 drivers from x86_64
 		sed -i \
-			-e '/_pick vkasahi/d' \
-			-e 's/vulkan-asahi//' \
-			-e 's/,asahi//g'      \
-			-e 's/,freedreno//g'  \
+			-e '/_pick vkfdreno/d' \
+			-e '/_pick vkasahi/d'  \
+			-e 's/vulkan-asahi//'  \
+			-e 's/,asahi//g'       \
+			-e 's/,freedreno//g'   \
 			./PKGBUILD
 		;;
 	aarch64)

--- a/mesa-nano.sh
+++ b/mesa-nano.sh
@@ -13,11 +13,12 @@ case "$ARCH" in
 		cd ./mesa
 		# remove aarch64 drivers from x86_64
 		sed -i \
-			-e '/_pick vkfdreno/d' \
-			-e '/_pick vkasahi/d'  \
-			-e 's/vulkan-asahi//'  \
-			-e 's/,asahi//g'       \
-			-e 's/,freedreno//g'   \
+			-e '/_pick vkfdreno/d'    \
+			-e '/_pick vkasahi/d'     \
+			-e 's/vulkan-freedreno//' \
+			-e 's/vulkan-asahi//'     \
+			-e 's/,asahi//g'          \
+			-e 's/,freedreno//g'      \
 			./PKGBUILD
 		;;
 	aarch64)

--- a/mesa-nano.sh
+++ b/mesa-nano.sh
@@ -13,8 +13,9 @@ case "$ARCH" in
 		cd ./mesa
 		# remove aarch64 drivers from x86_64
 		sed -i \
-			-e 's/,asahi//g'     \
-			-e 's/,freedreno//g' \
+			-e 's/vulkan-asahi//' \
+			-e 's/,asahi//g'      \
+			-e 's/,freedreno//g'  \
 			./PKGBUILD
 		;;
 	aarch64)

--- a/mesa-nano.sh
+++ b/mesa-nano.sh
@@ -13,6 +13,7 @@ case "$ARCH" in
 		cd ./mesa
 		# remove aarch64 drivers from x86_64
 		sed -i \
+			-e '/_pick vkasahi/d' \
 			-e 's/vulkan-asahi//' \
 			-e 's/,asahi//g'      \
 			-e 's/,freedreno//g'  \


### PR DESCRIPTION
The svga driver is needed for VMs. 

with `vulkan-asahi` now `aarch64` appimages will work on apple hardware.