### PR TITLE
remove cups backend from gtk4

### DIFF
--- a/gtk4-mini.sh
+++ b/gtk4-mini.sh
@@ -33,7 +33,9 @@ sed -i \
 	-e '/broadway/d'        \
 	-e '/sysprof=/d'        \
 	-e '/cloudproviders=/d' \
-	-e 's/-D colord=enabled/-D colord=enabled -D media-gstreamer=disabled -D vulkan=disabled -D build-testsuite=false/' \
+	-e '/libcups/d'         \
+	-e '/libcolord/d'       \
+	-e 's/-D colord=enabled/-D colord=disabled -D print-cups=disabled -D media-gstreamer=disabled -D vulkan=disabled -D build-testsuite=false/' \
 	./PKGBUILD
 
 cat ./PKGBUILD


### PR DESCRIPTION
This should reduce the size of the AppImages quite a bit since libcups depends on gnutls which depends on libleancrypto.

cc @fiftydinar @psadi let me know if anything breaks. 