### PR TITLE
make `mesa-nano` smaller again

### DIFF
--- a/mesa-mini.sh
+++ b/mesa-mini.sh
@@ -5,7 +5,7 @@ set -e
 get-pkgbuild
 cd "$BUILD_DIR"
 
-common_gallium='d3d12,nouveau,radeonsi,softpipe,svga,virgl,zink'
+common_gallium='d3d12,nouveau,radeonsi,softpipe,virgl,zink'
 x64_gallium="crocus,iris,r600,$common_gallium"
 arm_gallium="asahi,freedreno,nouveau,etnaviv,lima,panfrost,rocket,v3d,vc4,$common_gallium"
 

--- a/mesa-mini.sh
+++ b/mesa-mini.sh
@@ -67,6 +67,7 @@ rm -fv ./*-docs-*.pkg.tar.* ./*-debug-*.pkg.tar.*
 mv -v ./mesa-*.pkg.tar."$EXT"           ../mesa-mini-"$ARCH".pkg.tar."$EXT"
 mv -v ./vulkan-radeon-*.pkg.tar."$EXT"  ../vulkan-radeon-mini-"$ARCH".pkg.tar."$EXT"
 mv -v ./vulkan-nouveau-*.pkg.tar."$EXT" ../vulkan-nouveau-mini-"$ARCH".pkg.tar."$EXT"
+mv -v ./vulkan-virtio-*.pkg.tar."$EXT"  ../vulkan-virtio-nano-"$ARCH".pkg.tar."$EXT"
 
 if [ "$ARCH" = 'x86_64' ]; then
 	mv -v ./vulkan-intel-*.pkg.tar."$EXT" ../vulkan-intel-mini-"$ARCH".pkg.tar."$EXT"

--- a/mesa-nano.sh
+++ b/mesa-nano.sh
@@ -5,7 +5,7 @@ set -e
 get-pkgbuild
 cd "$BUILD_DIR"
 
-common_gallium='d3d12,nouveau,radeonsi,softpipe,svga,virgl,zink'
+common_gallium='d3d12,nouveau,radeonsi,softpipe,virgl,zink'
 x64_gallium="crocus,iris,r600,$common_gallium"
 arm_gallium="asahi,freedreno,nouveau,etnaviv,lima,panfrost,rocket,v3d,vc4,$common_gallium"
 

--- a/mesa-nano.sh
+++ b/mesa-nano.sh
@@ -5,7 +5,7 @@ set -e
 get-pkgbuild
 cd "$BUILD_DIR"
 
-common_gallium='d3d12,nouveau,radeonsi,softpipe,virgl,zink'
+common_gallium='nouveau,radeonsi,softpipe,virgl,zink'
 x64_gallium="crocus,iris,r600,$common_gallium"
 arm_gallium="asahi,freedreno,nouveau,etnaviv,lima,panfrost,rocket,v3d,vc4,$common_gallium"
 

--- a/mesa-nano.sh
+++ b/mesa-nano.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+sed -i -e 's|-O2|-Os -fno-strict-aliasing -fno-fast-math -fno-plt|' /etc/makepkg.conf
+
 get-pkgbuild
 cd "$BUILD_DIR"
 

--- a/mesa-nano.sh
+++ b/mesa-nano.sh
@@ -67,6 +67,7 @@ rm -fv ./*-docs-*.pkg.tar.* ./*-debug-*.pkg.tar.*
 mv -v ./mesa-*.pkg.tar."$EXT"           ../mesa-nano-"$ARCH".pkg.tar."$EXT"
 mv -v ./vulkan-radeon-*.pkg.tar."$EXT"  ../vulkan-radeon-nano-"$ARCH".pkg.tar."$EXT"
 mv -v ./vulkan-nouveau-*.pkg.tar."$EXT" ../vulkan-nouveau-nano-"$ARCH".pkg.tar."$EXT"
+mv -v ./vulkan-virtio-*.pkg.tar."$EXT"  ../vulkan-virtio-nano-"$ARCH".pkg.tar."$EXT"
 
 if [ "$ARCH" = 'x86_64' ]; then
 	mv -v ./vulkan-intel-*.pkg.tar."$EXT" ../vulkan-intel-nano-"$ARCH".pkg.tar."$EXT"

--- a/mesa-nano.sh
+++ b/mesa-nano.sh
@@ -7,7 +7,7 @@ sed -i -e 's|-O2|-Os -fno-strict-aliasing -fno-fast-math -fno-plt|' /etc/makepkg
 get-pkgbuild
 cd "$BUILD_DIR"
 
-common_gallium='nouveau,radeonsi,softpipe,virgl,zink'
+common_gallium='d3d12,nouveau,radeonsi,softpipe,virgl,zink'
 x64_gallium="crocus,iris,r600,$common_gallium"
 arm_gallium="asahi,freedreno,nouveau,etnaviv,lima,panfrost,rocket,v3d,vc4,$common_gallium"
 


### PR DESCRIPTION
I just asked AI why compiling mesa with `-Os` would break eden and GTK4 apps and told me some stuff abour ilegal code and suggested that I pass `-fno-strict-aliasing -fno-fast-math -fno-plt`

**It fixes the issue with Eden:** 

<img width="1426" height="873" alt="image" src="https://github.com/user-attachments/assets/10ea019c-e342-4f51-bc62-912c52ccd5c0" />

---

Now @fiftydinar can you tell me if you still have the issue with gtk4 apps? All you have to do is download [this](https://github.com/Samueru-sama/archlinux-pkgs-debloated/releases/download/continuous/mesa-nano-x86_64.pkg.tar.zst) and drop in replace the libs on any gtk4 appimage and run the `AppRun`. 

