### PR TITLE
remove `-fcf-protection` again and use safer `-Os`

### DIFF
--- a/bin/prepare-build
+++ b/bin/prepare-build
@@ -19,6 +19,7 @@ echo "Settings up build options..."
 sed -i \
 	-e 's|DEBUG_CFLAGS="-g"|DEBUG_CFLAGS="-g0"|' \
 	-e 's|-fno-omit-frame-pointer|-fomit-frame-pointer|' \
+	-e 's|-fcf-protection||' \
 	-e 's|-mno-omit-leaf-frame-pointer||' \
 	-e 's|-Wp,-D_FORTIFY_SOURCE=3||' \
 	-e 's|-fstack-clash-protection||' \

--- a/qt6-base-mini.sh
+++ b/qt6-base-mini.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sed -i -e 's|-O2|-Os|' /etc/makepkg.conf
+sed -i -e 's|-O2|-Os -fno-strict-aliasing -fno-fast-math|' /etc/makepkg.conf
 
 get-pkgbuild
 cd "$BUILD_DIR"


### PR DESCRIPTION
cc @crueter I'm not able to figure out what broke eden with the latest change that was reverted. As swapping the Qt libraries in the affected artifacts does not fix it, it seems the issue affects binaries compiled with the library and not at runtime, as the qt6-demo works fine.

I believe we are hitting some weird issue like https://github.com/pkgforge-dev/archlinux-pkgs-debloated/pull/52 which was caused by using `-Os` without `-fno-strict-aliasing -fno-fast-math`.

So this PR will add `-fno-strict-aliasing -fno-fast-math` and remove `-fcf-protection` (which is already removed in `aarch64`).

It should be fine, let me know when you are ready to merge this since this the only way to know if this works is by testing in production lol



