### PR TITLE
make a dedicated `makepkg.conf` instead of `sed` hacks.

### DIFF
--- a/aux/makepkg.conf.aarch64
+++ b/aux/makepkg.conf.aarch64
@@ -1,6 +1,19 @@
 #!/hint/bash
 # shellcheck disable=2034
 
+DLAGENTS=('file::/usr/bin/curl -qgC - -o %o %u'
+          'ftp::/usr/bin/curl -qgfC - --ftp-pasv --retry 3 --retry-delay 3 -o %o %u'
+          'http::/usr/bin/curl -qgb "" -fLC - --retry 3 --retry-delay 3 -o %o %u'
+          'https::/usr/bin/curl -qgb "" -fLC - --retry 3 --retry-delay 3 -o %o %u'
+          'rsync::/usr/bin/rsync --no-motd -z %u %o'
+          'scp::/usr/bin/scp -C %u %o')
+
+VCSCLIENTS=('bzr::breezy'
+            'fossil::fossil'
+            'git::git'
+            'hg::mercurial'
+            'svn::subversion')
+
 CARCH="aarch64"
 CHOST="aarch64-unknown-linux-gnu"
 

--- a/aux/makepkg.conf.aarch64
+++ b/aux/makepkg.conf.aarch64
@@ -1,0 +1,42 @@
+#!/hint/bash
+# shellcheck disable=2034
+
+CARCH="aarch64"
+CHOST="aarch64-unknown-linux-gnu"
+
+CPPFLAGS=""
+CFLAGS="-march=armv8-a -O2 -pipe -fno-plt -fexceptions -fno-fast-math \
+	-Wformat -fomit-frame-pointer -fno-strict-aliasing"
+CXXFLAGS="$CFLAGS -Wp,-D_GLIBCXX_ASSERTIONS"
+LDFLAGS="-Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now \
+		-Wl,-z,pack-relative-relocs"
+LTOFLAGS=""
+MAKEFLAGS="-j$(nproc)"
+DEBUG_CFLAGS="-g0"
+DEBUG_CXXFLAGS="$DEBUG_CFLAGS"
+
+BUILDENV=(!distcc color ccache check !sign)
+OPTIONS=(strip docs !libtool !staticlibs emptydirs zipman purge !debug !lto)
+
+INTEGRITY_CHECK=(sha256)
+STRIP_BINARIES="--strip-all"
+STRIP_SHARED="--strip-unneeded"
+STRIP_STATIC="--strip-debug"
+MAN_DIRS=(usr{,/local}{,/share}/{man,info})
+DOC_DIRS=(usr/{,local/}{,share/}{doc,gtk-doc})
+PURGE_TARGETS=(usr/{,share}/info/dir .packlist *.pod)
+DBGSRCDIR="/usr/src/debug"
+LIB_DIRS=('lib:usr/lib')
+
+PKGEXT='.pkg.tar.xz'
+SRCEXT='.src.tar.gz'
+
+COMPRESSGZ=(gzip -c -f -n)
+COMPRESSBZ2=(bzip2 -c -f)
+COMPRESSXZ=(xz -c -z -)
+COMPRESSZST=(zstd -c -T0 -)
+COMPRESSLRZ=(lrzip -q)
+COMPRESSLZO=(lzop -q)
+COMPRESSZ=(compress -c -f)
+COMPRESSLZ4=(lz4 -q)
+COMPRESSLZ=(lzip -c -f)

--- a/aux/makepkg.conf.x86_64
+++ b/aux/makepkg.conf.x86_64
@@ -1,0 +1,41 @@
+#!/hint/bash
+# shellcheck disable=2034
+
+CARCH="x86_64"
+CHOST="x86_64-pc-linux-gnu"
+
+CFLAGS="-march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions -fno-fast-math \
+		-Wformat -fcf-protection -fomit-frame-pointer -fno-strict-aliasing"
+CXXFLAGS="$CFLAGS -Wp,-D_GLIBCXX_ASSERTIONS"
+LDFLAGS="-Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now \
+		-Wl,-z,pack-relative-relocs"
+LTOFLAGS="-flto=auto"
+MAKEFLAGS="-j$(nproc)"
+DEBUG_CFLAGS="-g0"
+DEBUG_CXXFLAGS="$DEBUG_CFLAGS"
+
+BUILDENV=(!distcc color ccache check !sign)
+OPTIONS=(strip docs !libtool !staticlibs emptydirs zipman purge debug lto)
+
+INTEGRITY_CHECK=(sha256)
+STRIP_BINARIES="--strip-all"
+STRIP_SHARED="--strip-unneeded"
+STRIP_STATIC="--strip-debug"
+MAN_DIRS=({usr{,/local}{,/share},opt/*}/{man,info})
+DOC_DIRS=(usr/{,local/}{,share/}{doc,gtk-doc} opt/*/{doc,gtk-doc})
+PURGE_TARGETS=(usr/{,share}/info/dir .packlist *.pod)
+DBGSRCDIR="/usr/src/debug"
+LIB_DIRS=('lib:usr/lib' 'lib32:usr/lib32')
+
+PKGEXT='.pkg.tar.zst'
+SRCEXT='.src.tar.gz'
+
+COMPRESSGZ=(gzip -c -f -n)
+COMPRESSBZ2=(bzip2 -c -f)
+COMPRESSXZ=(xz -c -z -)
+COMPRESSZST=(zstd -c -T0 -)
+COMPRESSLRZ=(lrzip -q)
+COMPRESSLZO=(lzop -q)
+COMPRESSZ=(compress -c -f)
+COMPRESSLZ4=(lz4 -q)
+COMPRESSLZ=(lzip -c -f)

--- a/aux/makepkg.conf.x86_64
+++ b/aux/makepkg.conf.x86_64
@@ -1,6 +1,19 @@
 #!/hint/bash
 # shellcheck disable=2034
 
+DLAGENTS=('file::/usr/bin/curl -qgC - -o %o %u'
+          'ftp::/usr/bin/curl -qgfC - --ftp-pasv --retry 3 --retry-delay 3 -o %o %u'
+          'http::/usr/bin/curl -qgb "" -fLC - --retry 3 --retry-delay 3 -o %o %u'
+          'https::/usr/bin/curl -qgb "" -fLC - --retry 3 --retry-delay 3 -o %o %u'
+          'rsync::/usr/bin/rsync --no-motd -z %u %o'
+          'scp::/usr/bin/scp -C %u %o')
+
+VCSCLIENTS=('bzr::breezy'
+            'fossil::fossil'
+            'git::git'
+            'hg::mercurial'
+            'svn::subversion')
+
 CARCH="x86_64"
 CHOST="x86_64-pc-linux-gnu"
 

--- a/bin/prepare-build
+++ b/bin/prepare-build
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+echo "------------------------------------------------------------"
 echo "Installing basic packages..."
 pacman-key --init
 pacman -Syy --noconfirm archlinux-keyring
@@ -13,21 +14,13 @@ pacman -Syu --noconfirm \
 	ninja      \
 	sccache    \
 	wget
-echo "------------------------------------------------------------"
 
+echo "------------------------------------------------------------"
 echo "Settings up build options..."
-sed -i \
-	-e 's|DEBUG_CFLAGS="-g"|DEBUG_CFLAGS="-g0"|' \
-	-e 's|-fno-omit-frame-pointer|-fomit-frame-pointer|' \
-	-e 's|-mno-omit-leaf-frame-pointer||' \
-	-e 's|-Wp,-D_FORTIFY_SOURCE=3||' \
-	-e 's|-fstack-clash-protection||' \
-	-e 's|MAKEFLAGS=.*|MAKEFLAGS="-j$(nproc)"|' \
-	-e 's|!ccache|ccache|' \
-	-e 's|#MAKEFLAGS|MAKEFLAGS|' /etc/makepkg.conf
+cp -v ./aux/makepkg.conf."$(uname -m)" /etc/makepkg.conf
 cat /etc/makepkg.conf
-echo "------------------------------------------------------------"
 
+echo "------------------------------------------------------------"
 echo "Hacking makepkg to allow building as root in the container..."
 sed -i 's|EUID == 0|EUID == 69|g' /usr/bin/makepkg
 mkdir -p /usr/local/bin

--- a/ffmpeg-mini.sh
+++ b/ffmpeg-mini.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sed -i -e 's|-O2|-Os -fno-strict-aliasing -fno-fast-math -fno-plt|' /etc/makepkg.conf
+sed -i -e 's|-O2|-Os|' /etc/makepkg.conf
 
 get-pkgbuild
 cd "$BUILD_DIR"

--- a/glycin-mini.sh
+++ b/glycin-mini.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sed -i -e 's|-O2|-Os -fno-strict-aliasing -fno-fast-math -fno-plt|' /etc/makepkg.conf
+sed -i -e 's|-O2|-Os|' /etc/makepkg.conf
 
 export AUR_PACKAGE=glycin-ng
 

--- a/gtk2-mini.sh
+++ b/gtk2-mini.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sed -i -e 's|-O2|-Os -fno-strict-aliasing -fno-fast-math -fno-plt|' /etc/makepkg.conf
+sed -i -e 's|-O2|-Os|' /etc/makepkg.conf
 
 export AUR_PACKAGE=gtk2-ng-git
 

--- a/gtk3-mini.sh
+++ b/gtk3-mini.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sed -i -e 's|-O2|-Os -fno-strict-aliasing -fno-fast-math -fno-plt|' /etc/makepkg.conf
+sed -i -e 's|-O2|-Os|' /etc/makepkg.conf
 
 get-pkgbuild
 cd "$BUILD_DIR"

--- a/gtk4-mini.sh
+++ b/gtk4-mini.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sed -i -e 's|-O2|-Os -fno-strict-aliasing -fno-fast-math -fno-plt|' /etc/makepkg.conf
+sed -i -e 's|-O2|-Os|' /etc/makepkg.conf
 
 get-pkgbuild
 cd "$BUILD_DIR"

--- a/icu-mini.sh
+++ b/icu-mini.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sed -i -e 's|-O2|-Os -fno-strict-aliasing -fno-fast-math -fno-plt|' /etc/makepkg.conf
+sed -i -e 's|-O2|-Os|' /etc/makepkg.conf
 pacman -S --noconfirm wget unzip
 
 get-pkgbuild

--- a/intel-media-driver-mini.sh
+++ b/intel-media-driver-mini.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sed -i -e 's|-O2|-Os -fno-strict-aliasing -fno-fast-math -fno-plt|' /etc/makepkg.conf
+sed -i -e 's|-O2|-Os|' /etc/makepkg.conf
 
 get-pkgbuild
 cd "$BUILD_DIR"

--- a/libdecor-mini.sh
+++ b/libdecor-mini.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sed -i -e 's|-O2|-Os -fno-strict-aliasing -fno-fast-math -fno-plt|' /etc/makepkg.conf
+sed -i -e 's|-O2|-Os|' /etc/makepkg.conf
 
 export AUR_PACKAGE=libdecor-rs
 

--- a/librsvg-mini.sh
+++ b/librsvg-mini.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sed -i -e 's|-O2|-Os -fno-strict-aliasing -fno-fast-math -fno-plt|' /etc/makepkg.conf
+sed -i -e 's|-O2|-Os|' /etc/makepkg.conf
 
 get-pkgbuild
 cd "$BUILD_DIR"

--- a/libxml2-mini.sh
+++ b/libxml2-mini.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sed -i -e 's|-O2|-Os -fno-strict-aliasing -fno-fast-math -fno-plt|' /etc/makepkg.conf
+sed -i -e 's|-O2|-Os|' /etc/makepkg.conf
 
 get-pkgbuild
 cd "$BUILD_DIR"

--- a/llvm-mini.sh
+++ b/llvm-mini.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sed -i -e 's|-O2|-Os -fno-strict-aliasing -fno-fast-math -fno-plt|' /etc/makepkg.conf
+sed -i -e 's|-O2|-Os|' /etc/makepkg.conf
 
 get-pkgbuild
 cd "$BUILD_DIR"

--- a/llvm-nano.sh
+++ b/llvm-nano.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sed -i -e 's|-O2|-Os -fno-strict-aliasing -fno-fast-math -fno-plt|' /etc/makepkg.conf
+sed -i -e 's|-O2|-Os|' /etc/makepkg.conf
 
 get-pkgbuild
 cd "$BUILD_DIR"

--- a/mangohud-mini.sh
+++ b/mangohud-mini.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sed -i -e 's|-O2|-Os -fno-strict-aliasing -fno-fast-math -fno-plt|' /etc/makepkg.conf
+sed -i -e 's|-O2|-Os|' /etc/makepkg.conf
 
 get-pkgbuild
 cd "$BUILD_DIR"

--- a/mesa-nano.sh
+++ b/mesa-nano.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sed -i -e 's|-O2|-Os -fno-strict-aliasing -fno-fast-math -fno-plt|' /etc/makepkg.conf
+sed -i -e 's|-O2|-Os|' /etc/makepkg.conf
 
 get-pkgbuild
 cd "$BUILD_DIR"

--- a/mesa-zink-mini.sh
+++ b/mesa-zink-mini.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sed -i -e 's|-O2|-Os -fno-strict-aliasing -fno-fast-math -fno-plt|' /etc/makepkg.conf
+sed -i -e 's|-O2|-Os|' /etc/makepkg.conf
 
 export PACKAGE=mesa
 get-pkgbuild

--- a/qt6-base-mini.sh
+++ b/qt6-base-mini.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sed -i -e 's|-O2|-Os -fno-strict-aliasing -fno-fast-math|' /etc/makepkg.conf
+sed -i -e 's|-O2|-Os|' /etc/makepkg.conf
 
 get-pkgbuild
 cd "$BUILD_DIR"


### PR DESCRIPTION
In theory nothing should break here, since the resulting flags are the same after running the sed, though `-Werror=format-security` and `-fstack-protector-strong` were removed.

`-fno-strict-aliasing -fno-fast-math -fno-plt` are always enforced now, instead of what was done before which was adding them when `-Os` was used.

@crueter let me know when I can merge this. Heads up since this needs to be tested after being merged.