### PR TITLE
remove Intel OA perf metrics blob from mesa

### DIFF
--- a/mesa-mini.sh
+++ b/mesa-mini.sh
@@ -55,7 +55,32 @@ sed -i '/^  cd mesa-\$_pkgver$/a\
 	echo "Patching amdgpu DRM version check..."\
 	find . -name "ac_gpu_info.c" -print -exec sed -i "s/info->drm_minor < 54/info->drm_minor < 0/" {} \\;' "$PKGBUILD"
 
+# Replace gen_perf.py with a stub to drop the Intel OA performance-counter
+# metrics (~4.5MiB of const data for GL_INTEL_performance_query). The stub keeps
+# the same generated API (no-op intel_oa_register_queries_*), so iris/crocus and
+# intel_perf.c compile/link unchanged; the perf query extension just reports no
+# counters at runtime. Saves ~5MiB in libgallium.
+sed -i '/^  cd mesa-\$_pkgver$/a\
+	echo "Patching gen_perf.py (drop Intel OA perf metrics)..."\
+	cat > src/intel/perf/gen_perf.py <<PYEOF\
+import os, sys\
+args = sys.argv[1:]\
+code = args[args.index("--code") + 1]\
+header = args[args.index("--header") + 1]\
+gens = [os.path.basename(x)[3:-4] for x in args if os.path.basename(x).startswith("oa-")]\
+NL = chr(10)\
+Q = chr(34)\
+open(header, "w").write("#pragma once" + NL + "struct intel_perf_config;" + NL + "".join("void intel_oa_register_queries_" + g + "(struct intel_perf_config *perf);" + NL for g in gens))\
+open(code, "w").write("#include " + Q + "perf/intel_perf_metrics.h" + Q + NL + "".join("void intel_oa_register_queries_" + g + "(struct intel_perf_config *perf) { (void)perf; }" + NL for g in gens))\
+PYEOF' "$PKGBUILD"
+
 cat "$PKGBUILD"
+
+# fail loudly instead of silently shipping a package without the debloat.
+if ! grep -q "Patching gen_perf.py" "$PKGBUILD"; then
+	>&2 echo "Failed to patch gen_perf.py!"
+	exit 1
+fi
 
 # Do not build if version does not match with upstream
 if check-upstream-version; then

--- a/mesa-nano.sh
+++ b/mesa-nano.sh
@@ -57,7 +57,32 @@ sed -i '/^  cd mesa-\$_pkgver$/a\
 	echo "Patching amdgpu DRM version check..."\
 	find . -name "ac_gpu_info.c" -print -exec sed -i "s/info->drm_minor < 54/info->drm_minor < 0/" {} \\;' "$PKGBUILD"
 
+# Replace gen_perf.py with a stub to drop the Intel OA performance-counter
+# metrics (~4.5MiB of const data for GL_INTEL_performance_query). The stub keeps
+# the same generated API (no-op intel_oa_register_queries_*), so iris/crocus and
+# intel_perf.c compile/link unchanged; the perf query extension just reports no
+# counters at runtime. Saves ~5MiB in libgallium.
+sed -i '/^  cd mesa-\$_pkgver$/a\
+	echo "Patching gen_perf.py (drop Intel OA perf metrics)..."\
+	cat > src/intel/perf/gen_perf.py <<PYEOF\
+import os, sys\
+args = sys.argv[1:]\
+code = args[args.index("--code") + 1]\
+header = args[args.index("--header") + 1]\
+gens = [os.path.basename(x)[3:-4] for x in args if os.path.basename(x).startswith("oa-")]\
+NL = chr(10)\
+Q = chr(34)\
+open(header, "w").write("#pragma once" + NL + "struct intel_perf_config;" + NL + "".join("void intel_oa_register_queries_" + g + "(struct intel_perf_config *perf);" + NL for g in gens))\
+open(code, "w").write("#include " + Q + "perf/intel_perf_metrics.h" + Q + NL + "".join("void intel_oa_register_queries_" + g + "(struct intel_perf_config *perf) { (void)perf; }" + NL for g in gens))\
+PYEOF' "$PKGBUILD"
+
 cat "$PKGBUILD"
+
+# fail loudly instead of silently shipping a package without the debloat.
+if ! grep -q "Patching gen_perf.py" "$PKGBUILD"; then
+	>&2 echo "Failed to patch gen_perf.py!"
+	exit 1
+fi
 
 # Do not build if version does not match with upstream
 if check-upstream-version; then


### PR DESCRIPTION
This change removes **6 MIB from libgallium and the intel-vulkan libs!**

I need someone with intel to tell me everything works still though.

cc @fiftydinar can you check that everything works normally with your intel gpu? I'm gonna post a few builds on the demos with these changes in a bit.